### PR TITLE
[Fix for Mac] Push input and weights to MPS device for M1/M2 devices

### DIFF
--- a/composable_lora.py
+++ b/composable_lora.py
@@ -466,12 +466,12 @@ def lora_Linear_forward(self, input):
 
     if devices.device.type == 'mps': #ensure input and weights both live on mps in the same format
         input = input.to(device=devices.device, dtype=devices.dtype)
-        self_weight_cuda = self.weight.to(device=devices.device, dtype=devices.dtype) #pass to MPS
+        self_weight_mps = self.weight.to(device=devices.device, dtype=devices.dtype) #pass to MPS
         to_del = self.weight
         self.weight = None                    #delete CPU variable
         del to_del
         del self.weight                       #avoid pytorch 2.0 throwing exception
-        self.weight = self_weight_cuda        #load GPU data to self.weight
+        self.weight = self_weight_mps        #load GPU data to self.weight
     
     res = torch.nn.Linear_forward_before_lora(self, input)
     res = lora_forward(self, input, res)
@@ -520,12 +520,12 @@ def lora_Conv2d_forward(self, input):
 
     if devices.device.type == 'mps': #ensure input and weights both live on mps in the same format
         input = input.to(device=devices.device, dtype=devices.dtype)
-        self_weight_cuda = self.weight.to(device=devices.device, dtype=devices.dtype) #pass to MPS
+        self_weight_mps = self.weight.to(device=devices.device, dtype=devices.dtype) #pass to MPS
         to_del = self.weight
         self.weight = None                    #delete CPU variable
         del to_del
         del self.weight                       #avoid pytorch 2.0 throwing exception
-        self.weight = self_weight_cuda        #load GPU data to self.weight
+        self.weight = self_weight_mps        #load GPU data to self.weight
 
     res = torch.nn.Conv2d_forward_before_lora(self, input)
     res = lora_forward(self, input, res)


### PR DESCRIPTION
This fixes the `RuntimeError: Placeholder storage has not been allocated on MPS device!` I was getting on my M1 Macbook Pro. I was still occasionally getting an error relating to the bias format seemingly at random (the best kind of error is an unpredictable one), but adding `--no-half` to my launch params seems to have fixed that.

This was my first time actually delving into torch code, so hopefully this is the correct approach?

Tested on [A1111 v1.6.0-2-g4afaaf8a](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/4afaaf8a020c1df457bcf7250cb1c7f609699fa7), python: 3.10.13, torch: 2.3.0.dev20231219, checkpoint: [a3d7311d85](https://google.com/search?q=a3d7311d853f6ae3ff9dd3d762ac6bcca882476887ececd2dd50d3689c9aa3c1)

EDIT: Seems I forgot to commit the rename before pushing... oops ^.^; please rename `self_weight_cuda` to `self_weight_mps` :p